### PR TITLE
[NVSHAS-8797] NeuVector accepts vulnerability when using GitHub Actions scans.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM registry.suse.com/bci/bci-base:15.4
 RUN zypper in -y jq docker && zypper clean
 
 COPY run-scan.sh /usr/bin
+COPY utils.sh /usr/bin
 
 ENTRYPOINT ["/usr/bin/run-scan.sh"]

--- a/README.md
+++ b/README.md
@@ -77,19 +77,20 @@ The following inputs can be used in `step.with`:
 
 <!-- start inputs -->
 
-| **Input**                     | **Description**                                                                             | **Default**                | **Required** |
-| ----------------------------- | ------------------------------------------------------------------------------------------- | -------------------------- | ------------ |
-| **`image-registry`**          | Registry of the image to scan, e.g. `https://registry.organization.com/`                    |                            | **false**    |
-| **`image-registry-username`** | Username for the registry authentication                                                    |                            | **false**    |
-| **`image-registry-password`** | Password for the registry authentication                                                    |                            | **false**    |
-| **`image-repository`**        | Repository of the image to scan, e.g. `org/image-name`                                      |                            | **true**     |
-| **`image-tag`**               | Tag of the image to scan, e.g. `1.0.0`                                                      |                            | **true**     |
-| **`min-high-cves-to-fail`**   | Minimum CVEs with high severity to fail the job                                             | `0`                        | **false**    |
-| **`min-medium-cves-to-fail`** | Minimum CVEs with medium severity to fail the job                                           | `0`                        | **false**    |
-| **`cve-names-to-fail`**       | Comma-separated list of CVE names that make the job fail, e.g. `CVE-2021-4160,CVE-2022-0778 |                            | **false**    |
-| **`nv-scanner-image`**        | NeuVector Scanner image to use for scanning                                                 | `neuvector/scanner:latest` | **false**    |
-| **`output`**                  | Output format, one of: `text`, `json`, `csv`                                                | `text`                     | **false**    |
-| **`debug`**                   | Debug mode, on of: `true`, `false`                                                          | `false`                    | **false**    |
+| **Input**                     | **Description**                                                                                                                   | **Default**                | **Required** |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------ |
+| **`image-registry`**          | Registry of the image to scan, e.g. `https://registry.organization.com/`                                                          |                            | **false**    |
+| **`image-registry-username`** | Username for the registry authentication                                                                                          |                            | **false**    |
+| **`image-registry-password`** | Password for the registry authentication                                                                                          |                            | **false**    |
+| **`image-repository`**        | Repository of the image to scan, e.g. `org/image-name`                                                                            |                            | **true**     |
+| **`image-tag`**               | Tag of the image to scan, e.g. `1.0.0`                                                                                            |                            | **true**     |
+| **`min-high-cves-to-fail`**   | Minimum CVEs with high severity to fail the job                                                                                   | `0`                        | **false**    |
+| **`min-medium-cves-to-fail`** | Minimum CVEs with medium severity to fail the job                                                                                 | `0`                        | **false**    |
+| **`cve-names-to-fail`**       | Comma-separated list of CVE names(without spaces between the entries) that make the job fail, e.g. `CVE-2021-4160,CVE-2022-0778   |                            | **false**    |
+| **`cve-names-to-exempt`**     | Comma-separated list of CVE names(without spaces between the entries) that exempt the job fail, e.g. `CVE-2021-4160,CVE-2022-0778 |                            | **false**    |
+| **`nv-scanner-image`**        | NeuVector Scanner image to use for scanning                                                                                       | `neuvector/scanner:latest` | **false**    |
+| **`output`**                  | Output format, one of: `text`, `json`, `csv`                                                                                      | `text`                     | **false**    |
+| **`debug`**                   | Debug mode, on of: `true`, `false`                                                                                                | `false`                    | **false**    |
 
 <!-- end inputs -->
 
@@ -110,7 +111,7 @@ The following inputs can be used in `step.with`:
 <!-- start usage -->
 
 ```yaml
-- uses: neuvector/scan-action@main
+- uses: pohanhuangtw/scan-action@main
   with:
     # Registry of the image to scan, e.g. `https://registry.organization.com/`
     # Default:
@@ -138,13 +139,13 @@ The following inputs can be used in `step.with`:
     # Default: 0
     min-medium-cves-to-fail: ""
 
-    # Comma-separated list of CVE names(without spaces between the entries) that make the job fail, e.g.
-    # `CVE-2021-4160,CVE-2022-0778
+    # Comma-separated list of CVE names(without spaces between the entries) that make
+    # the job fail, e.g. `CVE-2021-4160,CVE-2022-0778
     # Default:
     cve-names-to-fail: ""
 
-    # CComma-separated list of CVE names(without spaces between the entries) that exempt the job fail, e.g.
-    # `CVE-2021-4160,CVE-2022-0778
+    # Comma-separated list of CVE names(without spaces between the entries) that
+    # exempt the job fail, e.g. `CVE-2021-4160,CVE-2022-0778
     # Default:
     cve-names-to-exempt: ""
 

--- a/README.md
+++ b/README.md
@@ -138,10 +138,15 @@ The following inputs can be used in `step.with`:
     # Default: 0
     min-medium-cves-to-fail: ""
 
-    # Comma-separated list of CVE names that make the job fail, e.g.
+    # Comma-separated list of CVE names(without spaces between the entries) that make the job fail, e.g.
     # `CVE-2021-4160,CVE-2022-0778
     # Default:
     cve-names-to-fail: ""
+
+    # CComma-separated list of CVE names(without spaces between the entries) that exempt the job fail, e.g.
+    # `CVE-2021-4160,CVE-2022-0778
+    # Default:
+    cve-names-to-exempt: ""
 
     # NeuVector Scanner image to use for scanning
     # Default: neuvector/scanner:latest

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,11 @@ inputs:
     required: false
     default: '0'
   cve-names-to-fail:
-    description: 'Comma-separated list of CVE names that make the job fail, e.g. `CVE-2021-4160,CVE-2022-0778'
+    description: 'Comma-separated list of CVE names(without spaces between the entries) that make the job fail, e.g. `CVE-2021-4160,CVE-2022-0778'
+    required: false
+    default: ''
+  cve-names-to-exempt:
+    description: 'Comma-separated list of CVE names(without spaces between the entries) that exempt the job fail, e.g. `CVE-2021-4160,CVE-2022-0778'
     required: false
     default: ''
   nv-scanner-image:
@@ -59,6 +63,7 @@ runs:
     HIGH_VUL_TO_FAIL: ${{ inputs.min-high-cves-to-fail }}
     MEDIUM_VUL_TO_FAIL: ${{ inputs.min-medium-cves-to-fail }}
     VUL_NAMES_TO_FAIL: ${{ inputs.cve-names-to-fail }}
+    VUL_NAMES_TO_EXEMPT: ${{ inputs.cve-names-to-exempt }}
     SCANNER_REPOSITORY: ${{ inputs.image-repository }}
     SCANNER_TAG: ${{ inputs.image-tag }}
     SCANNER_REGISTRY: ${{ inputs.image-registry }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "neuvector-image-scan-action",
+  "name": "scan-action",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/run-scan.sh
+++ b/run-scan.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source /usr/bin/utils.sh
 
 set -e
 
@@ -35,16 +36,16 @@ fi
 docker cp neuvector.scanner:/var/neuvector/scan_result.json scan_result.json
 docker rm neuvector.scanner
 
+VUL_EXEMPT_LIST=$(printf '["%s"]' "${VUL_NAMES_TO_EXEMPT//,/\",\"}")
+remmoveExemptCVEFromJson "scan_result.json" "$VUL_EXEMPT_LIST"
+
 VUL_NUM=$(cat scan_result.json | jq '.report.vulnerabilities | length')
 FOUND_HIGH=$(cat scan_result.json | jq '.report.vulnerabilities[] | select(.severity == "High") | .severity' | wc -l)
 FOUND_MEDIUM=$(cat scan_result.json | jq '.report.vulnerabilities[] | select(.severity == "Medium") | .severity' | wc -l)
 VUL_LIST=$(printf '["%s"]' "${VUL_NAMES_TO_FAIL//,/\",\"}")
 VUL_LIST_FOUND=$(cat scan_result.json | jq --arg arr "$VUL_LIST" '.report.vulnerabilities[] | select(.name as $n | $arr | index($n)) |.name')
 
-echo "::set-output name=vulnerability_count::${VUL_NUM}"
-echo "::set-output name=high_vulnerability_count::${FOUND_HIGH}"
-echo "::set-output name=medium_vulnerability_count::${FOUND_MEDIUM}"
-
+# we must count the high and med before we put.
 if [[ -n $VUL_LIST_FOUND ]]; then
   fail_reason="Found specific named vulnerabilities."
   scan_fail="true"
@@ -58,6 +59,7 @@ else
   fail_reason=""
   scan_fail="false"
 fi
+
 
 if [[ $scan_fail == "true" ]]; then
   summary="Image scanning failed. ${fail_reason}"
@@ -83,8 +85,6 @@ if [[ "$OUTPUT" == "text" ]]; then
   echo -e "Vulnerabilities grouped by packages:\n"
 
   jq -r '[.report.vulnerabilities | group_by(.package_name) | .[] | {package_name: .[0].package_name, vuls: [ (.[] | {name: .name, description: .description, severity: .severity}) ]}] | .[] | (.package_name) + ":\n" +  (.vuls | [.[] | .name + " (" + .severity + "): " + .description] | join("\n")) + "\n\n"' scan_result.json
-
-  echo -e "\n${summary}"
 fi
 
 if [[ "$OUTPUT" == "json" ]]; then
@@ -98,6 +98,8 @@ if [[ "$OUTPUT" == "csv" ]]; then
 
   cat scan_result.json | jq -r '['$labels'],(.'$query' | ['$vars'])|@csv'
 fi
+
+echo -e "\n${summary}"
 
 if [[ "$scan_fail" == "true" ]]; then
   exit 1;

--- a/run-scan.sh
+++ b/run-scan.sh
@@ -37,7 +37,7 @@ docker cp neuvector.scanner:/var/neuvector/scan_result.json scan_result.json
 docker rm neuvector.scanner
 
 VUL_EXEMPT_LIST=$(printf '["%s"]' "${VUL_NAMES_TO_EXEMPT//,/\",\"}")
-remmoveExemptCVEFromJson "scan_result.json" "$VUL_EXEMPT_LIST"
+filterOutExemptCVEsFromJson "scan_result.json" "$VUL_EXEMPT_LIST"
 
 VUL_NUM=$(cat scan_result.json | jq '.report.vulnerabilities | length')
 FOUND_HIGH=$(cat scan_result.json | jq '.report.vulnerabilities[] | select(.severity == "High") | .severity' | wc -l)

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+function remmoveExemptCVEFromJson() {
+    local scanResult="$1"
+    local exemptCVEsJson="$2"
+
+    local filterJson="$(cat "$scanResult")"
+
+    # Filter out the exempted CVEs from the top-level vulnerabilities array
+    filterJson=$(jq --argjson exemptions "$exemptCVEsJson" '
+        .report.vulnerabilities |= map(select(.name as $name | $exemptions | index($name) | not))
+    ' <<<"$filterJson")
+
+    # Filter out the exempted CVEs from the cves array in each module
+    filterJson=$(jq --argjson exemptions "$exemptCVEsJson" '
+        .report.modules |= map(
+            if .cves then 
+                .cves |= map(select(.name as $name | $exemptions | index($name) | not)) 
+            else 
+                . 
+            end
+        )
+    ' <<<"$filterJson")
+
+    if [ -n "$filterJson" ]; then
+        echo "$filterJson" > "$scanResult"
+    else    
+        echo "Error: Filtered Scan result JSON is empty. The original file will not be modified."
+        exit 1
+    fi
+}

--- a/utils.sh
+++ b/utils.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-function remmoveExemptCVEFromJson() {
+function filterOutExemptCVEsFromJson() {
     local scanResult="$1"
     local exemptCVEsJson="$2"
 


### PR DESCRIPTION
### Summary
1. Support Neuvector to accepts vulnerability when using GitHub Actions scans
2. Improve readme

### How to verify
Say we run the yaml with following format, make sure the cve-names-to-exempt not shows up in the output json
```yaml
name: Run NVSHAS-8797
on:
  workflow_dispatch:
jobs:
  build:
    name: Build
    runs-on: ubuntu-latest
    steps:
      - name: Scan Remote Image
        uses: pohanhuangtw/scan-action@NVSHAS-8797
        with:
          image-registry: https://registry.hub.docker.com
          image-registry-username: user
          image-registry-password: pwd
          image-repository: repo
          image-tag: version
          min-high-cves-to-fail: "5"
          min-medium-cves-to-fail: "5"
          output: json
          cve-names-to-exempt: "CVE-2021-23840,CVE-2020-1971"
```