### PR TITLE
[NVASHAS-8938] Add Critical CVE Severity to support CVSS v3 scores 9.0-10.0 (CI/CD tool)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,7 @@ runs:
   using: "docker"
   image: 'Dockerfile'
   env:
+    CRITICAL_VUL_TO_FAIL: ${{ inputs.min-critical-cves-to-fail }}
     HIGH_VUL_TO_FAIL: ${{ inputs.min-high-cves-to-fail }}
     MEDIUM_VUL_TO_FAIL: ${{ inputs.min-medium-cves-to-fail }}
     VUL_NAMES_TO_FAIL: ${{ inputs.cve-names-to-fail }}


### PR DESCRIPTION
### Summary
1. Add Critical CVE Severity to support CVSS v3 scores 9.0-10.0

### How to verify
update from the previous version, say previous version have 5 High, but in CVSS 3.0 is 4 High 1 Critical
And current threshold for high is 5.
1. if user didn't update the pipeline script => it should hold the previous result, which is fail
2. if user update the pipeline scripts and remain the high is 5, no setting for others => it should pass.