### PR TITLE
[NVASHAS-9009] Need to add "library/" prefix on repository when using standalone for Docker registry

### DIFF
--- a/run-scan.sh
+++ b/run-scan.sh
@@ -21,6 +21,8 @@ MEDIUM_VUL_TO_FAIL=${MEDIUM_VUL_TO_FAIL:-"0"}
 OUTPUT=${OUTPUT:-"text"}
 DEBUG=${DEBUG:-"false"}
 
+# Formulate the Repository
+SCANNER_REPOSITORY=$(prepareRepository "$SCANNER_REGISTRY_USERNAME" "$SCANNER_REGISTRY_PASSWORD" "$SCANNER_REPOSITORY" "$SCANNER_TAG")
 docker run --name neuvector.scanner ${REGISTRY_ARG} -e SCANNER_REPOSITORY=${SCANNER_REPOSITORY} -e SCANNER_TAG=${SCANNER_TAG} -e SCANNER_ON_DEMAND=true -v /var/run/docker.sock:/var/run/docker.sock ${NV_SCANNER_IMAGE} > scanner_output.log
 result=$?
 

--- a/utils.sh
+++ b/utils.sh
@@ -29,3 +29,78 @@ function filterOutExemptCVEsFromJson() {
         exit 1
     fi
 }
+
+send_get_request() {
+    local registryUsername="$1"
+    local registryPassword="$2"
+    local registryURL="$3"
+    local endpoint="$4"
+    curl -s -u "$registryUsername:$registryPassword" "$registryURL$endpoint"
+}
+
+# Function to list repositories
+list_repositories() {
+    local registryUsername="$1"
+    local registryPassword="$2"
+    local registryURL="$3"
+    local endpoint="/repositories/$registryUsername/"
+    send_get_request "$registryUsername" "$registryPassword" "$registryURL" "$endpoint" | jq -r '.results[].name'
+}
+
+# Function to list tags for a repository
+list_tags() {
+    local registryUsername="$1"
+    local registryPassword="$2"
+    local registryURL="$3"
+    local repository="$4"
+    local endpoint="/repositories/$registryUsername/$repository/tags"
+    send_get_request "$registryUsername" "$registryPassword" "$registryURL" "$endpoint" | jq -r '.results[].name'
+}
+
+# Function to get all repositories with tags
+get_all_repositories_with_tags_all() {
+    local registryUsername="$1"
+    local registryPassword="$2"
+    local registryURL="https://hub.docker.com/v2"
+    local repos=$(list_repositories "$registryUsername" "$registryPassword" "$registryURL")
+    local repo_set=()
+
+    for repo in $repos; do
+        local tags=$(list_tags "$registryUsername" "$registryPassword" "$registryURL" "$repo")
+        for tag in $tags; do
+            repo_set+=("$repo:$tag")
+        done
+    done
+
+    echo "${repo_set[@]}"
+}
+
+        
+# Repository will be formulated to "{username}/{repository}".
+# If the username is empty, consider it a public registry and add "library/" prefix.
+# If the input already contains a "/", we consider it already formulated.
+function prepareRepository() {
+    local registryUsername="$1"
+    local registryPassword="$2"
+    local currentRepo="$3"
+    local tag="$4"
+    local repo_set
+    local formulateRepository="$3"
+
+    # Capture the output of the function into a variable
+    repo_set=$(get_all_repositories_with_tags_all "$registryUsername" "$registryPassword")
+
+    if [[ -n "$registryUsername" ]]; then
+        # Extract the base name of the currentRepo (i.e., the last part after the last '/')
+        local repoBaseName=$(basename "$currentRepo")
+
+        # Check if the repository:tag combination exists in the repo_set array
+        if [[ " ${repo_set[@]} " =~ " $repoBaseName:$tag " ]]; then
+            formulateRepository="$registryUsername/$repoBaseName"
+        else
+            formulateRepository="library/$repoBaseName"
+        fi
+    fi
+
+    echo "$formulateRepository"
+}


### PR DESCRIPTION
### Summary
Add "library/" or username prefix on repository when scanning, if user try to scanning the public the image in the pipeline, we handle the formulation for them.

### How to verify
1. Scan nginx or other public image but not in the private registry, and scan it.
2. Make sure we are able to scan, and the result meet the expectation.