### PR TITLE
chore: update readme with pin sha in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build image
         run: |
           docker build -t registry.organization.com/org/image-name:${{ github.sha }} .
       - name: Scan Image
-        uses: neuvector/scan-action@main
+        uses: neuvector/scan-action@dc98ca3e206249d47f00d884f04dd9905a94f156
         with:
           image-repository: registry.organization.com/org/image-name
           image-tag: ${{ github.sha }}
@@ -56,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Scan Remote Image
-        uses: neuvector/scan-action@main
+        uses: neuvector/scan-action@dc98ca3e206249d47f00d884f04dd9905a94f156
         with:
           image-registry: https://registry.organization.com/
           image-registry-username: ${{ secrets.RegistryUsername }}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
         run: |
           docker build -t registry.organization.com/org/image-name:${{ github.sha }} .
       - name: Scan Image
-        uses: neuvector/scan-action@dc98ca3e206249d47f00d884f04dd9905a94f156
+        uses: neuvector/scan-action@196964fb269cfcd1fe139dd27c8440a8396bd8ab #v1.0.0
         with:
           image-repository: registry.organization.com/org/image-name
           image-tag: ${{ github.sha }}
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Scan Remote Image
-        uses: neuvector/scan-action@dc98ca3e206249d47f00d884f04dd9905a94f156
+        uses: neuvector/scan-action@196964fb269cfcd1fe139dd27c8440a8396bd8ab #v1.0.0
         with:
           image-registry: https://registry.organization.com/
           image-registry-username: ${{ secrets.RegistryUsername }}


### PR DESCRIPTION
### Summary
- pin sha in readme
- dc98ca3e206249d47f00d884f04dd9905a94f156 is the latest commits for Pin GH action to sha commits